### PR TITLE
fix[db]: create migration for unique user roles index with soft-delete(BUG-3842) 

### DIFF
--- a/src/database/migrations/20250925122507-update-unique-user-roles.js
+++ b/src/database/migrations/20250925122507-update-unique-user-roles.js
@@ -1,0 +1,32 @@
+// 20250925120000-update-unique-user-roles.js
+module.exports = {
+	up: async (queryInterface, Sequelize) => {
+		const table = 'user_roles'
+
+		// drop old constraint if it exists
+		await queryInterface.sequelize.query(
+			`ALTER TABLE "${table}" DROP CONSTRAINT IF EXISTS unique_title_org_id_tenant_code;`
+		)
+
+		// create partial unique index ignoring soft-deleted rows
+		await queryInterface.sequelize.query(
+			`CREATE UNIQUE INDEX IF NOT EXISTS unique_title_org_id_tenant_code 
+       ON "${table}" (title, organization_id, tenant_code) 
+       WHERE deleted_at IS NULL;`
+		)
+	},
+
+	down: async (queryInterface, Sequelize) => {
+		const table = 'user_roles'
+
+		// drop the partial index
+		await queryInterface.sequelize.query(`DROP INDEX IF EXISTS unique_title_org_id_tenant_code;`)
+
+		// restore original constraint (no WHERE clause)
+		await queryInterface.addConstraint(table, {
+			fields: ['title', 'organization_id', 'tenant_code'],
+			type: 'unique',
+			name: 'unique_title_org_id_tenant_code',
+		})
+	},
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Creating a role with the same name in the same organization is now allowed after the previous role was soft-deleted, preventing erroneous “duplicate” errors.
  * Improves consistency of role management in multi-tenant setups.

* **Chores**
  * Database migration to align uniqueness behavior with soft-delete logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->