### PR TITLE
Disable automatic tenant registration by default

### DIFF
--- a/src/database/migrations/20260713122708-update-auto-register-tenant-configuration.js
+++ b/src/database/migrations/20260713122708-update-auto-register-tenant-configuration.js
@@ -7,12 +7,15 @@ module.exports = {
 		await queryInterface.changeColumn('tenants', 'configuration', {
 			type: Sequelize.JSONB,
 			allowNull: false,
-			defaultValue: common.DEFAULT_TENANT_CONFIGURATION,
+			defaultValue: null,
 		})
 
 		await queryInterface.sequelize.query(
 			`UPDATE tenants
-			 SET configuration = jsonb_set(configuration, '{auto_register}', 'false'::jsonb)`
+			 SET configuration = jsonb_set(
+        jsonb_set(configuration, '{auto_register}', 'false'::jsonb),
+        '{allowed_auth_mode}', '["password"]'::jsonb
+      )`
 		)
 	},
 
@@ -20,15 +23,14 @@ module.exports = {
 		await queryInterface.changeColumn('tenants', 'configuration', {
 			type: Sequelize.JSONB,
 			allowNull: false,
-			defaultValue: {
-				allowed_auth_mode: ['otp', 'password'],
-				auto_register: true,
-			},
+			defaultValue: common.DEFAULT_TENANT_CONFIGURATION,
 		})
 
 		await queryInterface.sequelize.query(
 			`UPDATE tenants
-			 SET configuration = jsonb_set(configuration, '{auto_register}', 'true'::jsonb)`
+			 SET configuration = jsonb_set(
+        jsonb_set(configuration, '{auto_register}', 'true'::jsonb),
+        '{allowed_auth_mode}', '["otp","password"]'::jsonb)`
 		)
 	},
 }

--- a/src/database/migrations/20260713122708-update-auto-register-tenant-configuration.js
+++ b/src/database/migrations/20260713122708-update-auto-register-tenant-configuration.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const common = require('@constants/common')
+
+module.exports = {
+	up: async (queryInterface, Sequelize) => {
+		await queryInterface.changeColumn('tenants', 'configuration', {
+			type: Sequelize.JSONB,
+			allowNull: false,
+			defaultValue: common.DEFAULT_TENANT_CONFIGURATION,
+		})
+
+		await queryInterface.sequelize.query(
+			`UPDATE tenants
+			 SET configuration = jsonb_set(configuration, '{auto_register}', 'false'::jsonb)`
+		)
+	},
+
+	down: async (queryInterface, Sequelize) => {
+		await queryInterface.changeColumn('tenants', 'configuration', {
+			type: Sequelize.JSONB,
+			allowNull: false,
+			defaultValue: {
+				allowed_auth_mode: ['otp', 'password'],
+				auto_register: true,
+			},
+		})
+
+		await queryInterface.sequelize.query(
+			`UPDATE tenants
+			 SET configuration = jsonb_set(configuration, '{auto_register}', 'true'::jsonb)`
+		)
+	},
+}

--- a/src/envVariables.js
+++ b/src/envVariables.js
@@ -519,7 +519,7 @@ let enviromentVariables = {
 	DEFAULT_ALLOWED_AUTH_MODES: {
 		message: 'Required DEFAULT_ALLOWED_AUTH_MODES',
 		optional: true,
-		default: ['otp', 'password'],
+		default: ['password'],
 	},
 	DEFAULT_AUTO_REGISTER: {
 		message: 'Required DEFAULT_AUTO_REGISTER',

--- a/src/envVariables.js
+++ b/src/envVariables.js
@@ -524,7 +524,7 @@ let enviromentVariables = {
 	DEFAULT_AUTO_REGISTER: {
 		message: 'Required DEFAULT_AUTO_REGISTER',
 		optional: true,
-		default: true,
+		default: false,
 	},
 }
 let success = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tenant configuration defaults so automatic registration is disabled by default.
  * Updated existing tenant records to match the new default settings.
  * Adjusted environment-based configuration to default automatic registration to disabled when no value is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->